### PR TITLE
Bump busybox from 1.35 to 1.37 to resolve TLS errors

### DIFF
--- a/charts/stable-diffusion/templates/statefulset.yaml
+++ b/charts/stable-diffusion/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: ensure-stable-models
-          image: busybox:1.35
+          image: busybox:1.37
           command: ["/bin/sh"]
           args:
             - -c


### PR DESCRIPTION
This solves the TLS issues that prevent pod initialization, described in https://github.com/amithkk/stable-diffusion-k8s/issues/7 (for me, hopefully for everyone)